### PR TITLE
fixing tos_on_public_shares

### DIFF
--- a/lib/Checker.php
+++ b/lib/Checker.php
@@ -21,7 +21,6 @@
 
 namespace OCA\TermsOfService;
 
-use OC;
 use OCA\TermsOfService\AppInfo\Application;
 use OCA\TermsOfService\Db\Mapper\SignatoryMapper;
 use OCA\TermsOfService\Db\Mapper\TermsMapper;
@@ -72,8 +71,7 @@ class Checker {
 	public function currentUserHasSigned(): bool {
 		$uuid = $this->config->getAppValue(Application::APPNAME, 'term_uuid', '');
 		if ($this->userId === null) {
-			$config = OC::$server->getConfig();
-			if ($config->getAppValue(Application::APPNAME, 'tos_on_public_shares', '0') === '0') {
+			if ($this->config->getAppValue(Application::APPNAME, 'tos_on_public_shares', '0') === '0') {
 				return true;
 			}
 

--- a/lib/Checker.php
+++ b/lib/Checker.php
@@ -21,6 +21,7 @@
 
 namespace OCA\TermsOfService;
 
+use OC;
 use OCA\TermsOfService\AppInfo\Application;
 use OCA\TermsOfService\Db\Mapper\SignatoryMapper;
 use OCA\TermsOfService\Db\Mapper\TermsMapper;
@@ -71,6 +72,11 @@ class Checker {
 	public function currentUserHasSigned(): bool {
 		$uuid = $this->config->getAppValue(Application::APPNAME, 'term_uuid', '');
 		if ($this->userId === null) {
+			$config = OC::$server->getConfig();
+			if ($config->getAppValue(Application::APPNAME, 'tos_on_public_shares', '0') === '0') {
+				return true;
+			}
+
 			return ($this->session->get('term_uuid') === $uuid);
 		}
 

--- a/lib/Filesystem/Helper.php
+++ b/lib/Filesystem/Helper.php
@@ -97,9 +97,7 @@ class Helper {
 	}
 
 	public function verifyAccess(string $path): bool {
-		$config = OC::$server->getConfig();
-		if ($config->getAppValue(Application::APPNAME, 'tos_on_public_shares', '0') !== '1'
-			|| !$this->isBlockable($path)) {
+		if (!$this->isBlockable($path)) {
 			return true;
 		}
 


### PR DESCRIPTION
should fix #471

On a side note, he fact that you have to specify tos_on_public_shares to force ToS is not really the smartest thing here. We could get ride of the configuration and force public shares to be under ToS.

Now, this will enforce the ToS on public shares, and cancel the ToS on public shares (if userId is null) if tos_on_public_shares is NOT set (or set to '0' (zero).

Also, I failed and created the branch on stable21...