### PR TITLE
Fix tos_on_public_shares

### DIFF
--- a/lib/Checker.php
+++ b/lib/Checker.php
@@ -71,6 +71,10 @@ class Checker {
 	public function currentUserHasSigned(): bool {
 		$uuid = $this->config->getAppValue(Application::APPNAME, 'term_uuid', '');
 		if ($this->userId === null) {
+			if ($this->config->getAppValue(Application::APPNAME, 'tos_on_public_shares', '0') === '0') {
+				return true;
+			}
+
 			return ($this->session->get('term_uuid') === $uuid);
 		}
 

--- a/lib/Filesystem/Helper.php
+++ b/lib/Filesystem/Helper.php
@@ -110,9 +110,7 @@ class Helper {
 	}
 
 	public function verifyAccess(string $path): bool {
-		$config = OC::$server->getConfig();
-		if ($config->getAppValue(Application::APPNAME, 'tos_on_public_shares', '0') !== '1'
-			|| !$this->isBlockable($path)) {
+		if (!$this->isBlockable($path)) {
 			return true;
 		}
 

--- a/lib/Filesystem/Helper.php
+++ b/lib/Filesystem/Helper.php
@@ -21,13 +21,11 @@
 
 namespace OCA\TermsOfService\Filesystem;
 
-use OC;
 use OC\Core\Controller\ClientFlowLoginController;
 use OC\Core\Controller\ClientFlowLoginV2Controller;
 use OC\Core\Controller\LoginController;
 use OCA\Files_Sharing\Controller\ShareController;
 use OCA\Registration\Controller\RegisterController;
-use OCA\TermsOfService\AppInfo\Application;
 use OCA\TermsOfService\Checker;
 
 class Helper {


### PR DESCRIPTION
These are the same changes as in #491 but on master branch.

@daita I confirm it works now! ToS check is done correctly for normal files (not the public shares), whatever the `tos_on_public_shares` value.

fixes #471