### PR TITLE
Fix a-color on registration form

### DIFF
--- a/css/overlay.scss
+++ b/css/overlay.scss
@@ -55,6 +55,7 @@
 
 		a {
 			text-decoration: underline;
+			color: var(--color-main-text) !important;
 		}
 	}
 }


### PR DESCRIPTION
Dark mode already worked, the problem is there is a `#body-login a` rule setting the color to white:
https://github.com/nextcloud/server/blob/69290781ff0a59e72c1cf7c9c3b1c6a5ffc2596a/core/css/guest.css#L38-L41


Before | After
---|---
![Bildschirmfoto von 2021-04-26 09-03-08](https://user-images.githubusercontent.com/213943/116042181-69687980-a66e-11eb-9b43-128e7be0eccb.png) | ![Bildschirmfoto von 2021-04-26 09-02-25](https://user-images.githubusercontent.com/213943/116042210-6ff6f100-a66e-11eb-9599-6ca9b1d1cde4.png)
![Bildschirmfoto von 2021-04-26 09-02-19](https://user-images.githubusercontent.com/213943/116042235-75543b80-a66e-11eb-804f-c154ebc0d542.png) | ![Bildschirmfoto von 2021-04-26 09-02-19](https://user-images.githubusercontent.com/213943/116042235-75543b80-a66e-11eb-804f-c154ebc0d542.png)