### PR TITLE
Handle IP addresses which only return a continent, not a country

### DIFF
--- a/lib/CountryDetector.php
+++ b/lib/CountryDetector.php
@@ -49,7 +49,7 @@ class CountryDetector {
 			return CountryMapper::GLOBAL;
 		}
 
-		if ($record === null) {
+		if ($record === null || !isset($record['country']['iso_code'])) {
 			// No match found, e.g. for local address like 127.0.0.1
 			return CountryMapper::GLOBAL;
 		}


### PR DESCRIPTION
```json
{
  "continent": {
    "code": "EU",
    "geoname_id": …,
    "names": {
      "de": "Europa",
      "en": "Europe",
      "es": "Europa",
      "fr": "Europe",
      "ja": "ヨーロッパ",
      "pt-BR": "Europa",
      "ru": "Европа",
      "zh-CN": "欧洲"
    }
  }
}
```

Fix #690 