### PR TITLE
Exit earlier if no terms have to be accepted

### DIFF
--- a/lib/Checker.php
+++ b/lib/Checker.php
@@ -81,19 +81,15 @@ class Checker {
 			if ($this->config->getAppValue(Application::APPNAME, 'tos_on_public_shares', '0') === '0') {
 				return true;
 			}
-
-			return ($this->session->get('term_uuid') === $uuid);
-		}
-
-		if ($this->config->getAppValue(Application::APPNAME, 'tos_for_users', '1') !== '1') {
-			return true;
+		} else {
+			if ($this->config->getAppValue(Application::APPNAME, 'tos_for_users', '1') !== '1') {
+				return true;
+			}
 		}
 
 		if ($this->session->get('term_uuid') === $uuid) {
 			return true;
 		}
-
-		$user = $this->userManager->get($this->userId);
 
 		$countryCode = $this->countryDetector->getCountry();
 		$terms = $this->termsMapper->getTermsForCountryCode($countryCode);
@@ -101,6 +97,12 @@ class Checker {
 			// No terms that would need accepting
 			return true;
 		}
+
+		if ($this->userId === null) {
+			return false;
+		}
+
+		$user = $this->userManager->get($this->userId);
 
 		$signatories = $this->signatoryMapper->getSignatoriesByUser($user);
 		if (!empty($signatories)) {


### PR DESCRIPTION
When there are no terms to sign, [users are never prompted to accept something](https://github.com/nextcloud/terms_of_service/blob/341642dcae613456bbd80a2bd07c5e8996ca29ea/src/UserApp.vue#L92), so `Checker::currentUserHasSigned` will always return `false` for anonymous guests.

This PR makes sure that we return `true` when there are no terms to sign for the guests.