### PR TITLE
Avoid repeated DB queries just to fetch an empty TOS.

### DIFF
--- a/lib/Checker.php
+++ b/lib/Checker.php
@@ -44,6 +44,8 @@ class Checker {
 	private $countryDetector;
 	/** @var IConfig */
 	private $config;
+	/** @var array */
+	private $termsCache = [];
 
 	public function __construct(
 		$userId,
@@ -92,8 +94,10 @@ class Checker {
 		}
 
 		$countryCode = $this->countryDetector->getCountry();
-		$terms = $this->termsMapper->getTermsForCountryCode($countryCode);
-		if (empty($terms)) {
+		if (!array_key_exists($countryCode, $this->termsCache)) {
+			$this->termsCache[$countryCode] = $this->termsMapper->getTermsForCountryCode($countryCode);
+		}
+		if (empty($this->termsCache[$countryCode])) {
 			// No terms that would need accepting
 			return true;
 		}


### PR DESCRIPTION
Rationale: it is not necessary to repeatedly query for the TOS from the
DB in the same web-request.

Of course: if I have not configured TOS and do not intend to do so, then
I can as well disable the app ;) So this is somehow an edge case.