### PR TITLE
Add occ commands to create, update or delete TOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- OCC commands to change or delete TOS
 
 ## 2.3.1 – 2023-09-12
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -37,6 +37,10 @@ This product includes GeoLite2 data created by MaxMind, available from [maxmind.
 			<step>OCA\TermsOfService\Migration\CreateNotifications</step>
 		</install>
 	</repair-steps>
+    <commands>
+        <command>OCA\TermsOfService\Command\SetTermsCommand</command>
+        <command>OCA\TermsOfService\Command\DeleteTermsCommand</command>
+    </commands>
 
 	<settings>
 		<admin>OCA\TermsOfService\Settings\Admin</admin>

--- a/lib/Command/DeleteTermsCommand.php
+++ b/lib/Command/DeleteTermsCommand.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023, Marius David Wieschollek (github.public@mdns.eu)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\TermsOfService\Command;
+
+use OCA\TermsOfService\Db\Mapper\CountryMapper;
+use OCA\TermsOfService\Db\Mapper\LanguageMapper;
+use OCA\TermsOfService\Db\Mapper\SignatoryMapper;
+use OCA\TermsOfService\Db\Mapper\TermsMapper;
+use OCA\TermsOfService\Exceptions\TermsNotFoundException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DeleteTermsCommand extends Command {
+
+    public function __construct(
+        protected TermsMapper    $termsMapper,
+        protected CountryMapper  $countryMapper,
+        protected LanguageMapper $languageMapper,
+        protected SignatoryMapper $signatoryMapper,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void {
+        $this->setName('terms_of_service:term:delete')
+             ->addOption('country', 'c', InputOption::VALUE_OPTIONAL, 'The country code for the tos. Global if none given')
+             ->addOption('language', 'l', InputOption::VALUE_REQUIRED, 'The language code for the tos')
+             ->setDescription('Delete tos for the given country and language');
+    }
+
+    /**
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int {
+        $countryCode  = $input->getOption('country');
+        $languageCode = $input->getOption('language');
+
+        if($countryCode === null) {
+            $countryCode = CountryMapper::GLOBAL;
+        }
+
+        if(!$this->countryMapper->isValidCountry($countryCode)) {
+            $output->writeln("The given country is invalid");
+
+            return Command::FAILURE;
+        }
+
+        if(!$this->languageMapper->isValidLanguage($languageCode)) {
+            $output->writeln("The given language is invalid");
+
+            return Command::FAILURE;
+        }
+
+        if($this->deleteTos($countryCode, $languageCode)) {
+            $output->writeln(sprintf("TOS for %s %s have been deleted", $countryCode, $languageCode));
+            return Command::SUCCESS;
+        }
+
+
+        $output->writeln(sprintf("TOS for %s %s could not be deleted", $countryCode, $languageCode));
+        return Command::FAILURE;
+    }
+
+    protected function deleteTos(string $countryCode, string $languageCode): bool {
+        try {
+            $terms = $this->termsMapper->getTermsForCountryCodeAndLanguageCode($countryCode, $languageCode);
+        } catch(TermsNotFoundException $e) {
+            return false;
+        }
+
+        $this->termsMapper->delete($terms);
+        $this->signatoryMapper->deleteTerm($terms);
+
+        return true;
+    }
+}

--- a/lib/Command/SetTermsCommand.php
+++ b/lib/Command/SetTermsCommand.php
@@ -21,7 +21,6 @@
 
 namespace OCA\TermsOfService\Command;
 
-use OCA\Passwords\Exception\Command\NonInteractiveShellException;
 use OCA\TermsOfService\Db\Entities\Terms;
 use OCA\TermsOfService\Db\Mapper\CountryMapper;
 use OCA\TermsOfService\Db\Mapper\LanguageMapper;

--- a/lib/Command/SetTermsCommand.php
+++ b/lib/Command/SetTermsCommand.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023, Marius David Wieschollek (github.public@mdns.eu)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\TermsOfService\Command;
+
+use OCA\Passwords\Exception\Command\NonInteractiveShellException;
+use OCA\TermsOfService\Db\Entities\Terms;
+use OCA\TermsOfService\Db\Mapper\CountryMapper;
+use OCA\TermsOfService\Db\Mapper\LanguageMapper;
+use OCA\TermsOfService\Db\Mapper\TermsMapper;
+use OCA\TermsOfService\Exceptions\TermsNotFoundException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SetTermsCommand extends Command {
+
+    public function __construct(
+        protected TermsMapper    $termsMapper,
+        protected CountryMapper  $countryMapper,
+        protected LanguageMapper $languageMapper,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void {
+        $this->setName('terms_of_service:term:set')
+             ->addOption('country', 'c', InputOption::VALUE_OPTIONAL, 'The country code for the tos. Global if none given')
+             ->addOption('language', 'l', InputOption::VALUE_REQUIRED, 'The language code for the tos')
+             ->addArgument('text', InputArgument::REQUIRED, 'The text of the tos')
+             ->setDescription('Create or update a tos for the given country and language');
+    }
+
+    /**
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int {
+        $countryCode  = $input->getOption('country');
+        $languageCode = $input->getOption('language');
+        $body         = $input->getArgument('text');
+
+        if($countryCode === null) {
+            $countryCode = CountryMapper::GLOBAL;
+        }
+
+        if(!$this->countryMapper->isValidCountry($countryCode)) {
+            $output->writeln("The given country is invalid");
+
+            return Command::FAILURE;
+        }
+
+        if(!$this->languageMapper->isValidLanguage($languageCode)) {
+            $output->writeln("The given language is invalid");
+
+            return Command::FAILURE;
+        }
+
+        if(empty($body)) {
+            $output->writeln("No text given. If you want to delete the tos, use terms_of_service:term:delete");
+
+            return Command::FAILURE;
+        }
+
+        $this->saveTos($countryCode, $languageCode, $body);
+        $output->writeln(sprintf("TOS for %s %s have been updated", $countryCode, $languageCode));
+
+        return Command::SUCCESS;
+    }
+
+    protected function saveTos(string $countryCode, string $languageCode, string $body): void {
+        try {
+            $terms = $this->termsMapper->getTermsForCountryCodeAndLanguageCode($countryCode, $languageCode);
+        } catch(TermsNotFoundException $e) {
+            $terms = new Terms();
+        }
+
+        /**
+         * Replace escaped new line statements with working ones
+         */
+        $body = str_replace('\\n', "\n", $body);
+
+        $terms->setCountryCode($countryCode);
+        $terms->setLanguageCode($languageCode);
+        $terms->setBody($body);
+
+        if(!empty($terms->getId())) {
+            $this->termsMapper->update($terms);
+        } else {
+            $this->termsMapper->insert($terms);
+        }
+    }
+}

--- a/tests/DeleteTermsCommandTest.php
+++ b/tests/DeleteTermsCommandTest.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023, Marius David Wieschollek (github.public@mdns.eu)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\TermsOfService\Tests;
+
+use OCA\TermsOfService\Command\DeleteTermsCommand;
+use OCA\TermsOfService\Db\Entities\Terms;
+use OCA\TermsOfService\Db\Mapper\CountryMapper;
+use OCA\TermsOfService\Db\Mapper\LanguageMapper;
+use OCA\TermsOfService\Db\Mapper\SignatoryMapper;
+use OCA\TermsOfService\Db\Mapper\TermsMapper;
+use OCA\TermsOfService\Exceptions\TermsNotFoundException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\Input;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+/**
+ * @group Command
+ */
+class DeleteTermsCommandTest extends TestCase {
+
+    /** @var CountryMapper|MockObject */
+    protected $countryMapper;
+
+    /** @var TermsMapper|MockObject */
+    protected $termsMapper;
+
+    /** @var LanguageMapper|MockObject */
+    protected $languageMapper;
+
+    /** @var SignatoryMapper|MockObject */
+    protected $signatoryMapper;
+
+    /** @var Input|MockObject */
+    protected $inputInterface;
+
+    /** @var ConsoleOutput|MockObject */
+    protected $outputInterface;
+
+    /** @var DeleteTermsCommand */
+    protected $command;
+
+    protected function setUp(): void {
+        $this->countryMapper = $this->createMock(CountryMapper::class);
+        $this->termsMapper = $this->createMock(TermsMapper::class);
+        $this->languageMapper = $this->createMock(LanguageMapper::class);
+        $this->signatoryMapper = $this->createMock(SignatoryMapper::class);
+        $this->inputInterface = $this->createMock(Input::class);
+        $this->outputInterface = $this->createMock(ConsoleOutput::class);
+
+        $this->command = new DeleteTermsCommand(
+            $this->termsMapper,
+            $this->countryMapper,
+            $this->languageMapper,
+            $this->signatoryMapper,
+        );
+    }
+
+    public function testDeletesExistingTerms() {
+        $this->inputInterface->method('getOption')->willReturnMap(
+            [
+                ['country', 'us'],
+                ['language', 'en'],
+            ]
+        );
+
+        $this->countryMapper->expects($this->once())
+                            ->method('isValidCountry')
+                            ->with('us')
+                            ->willReturn(true);
+
+        $this->languageMapper->expects($this->once())
+                             ->method('isValidLanguage')
+                             ->with('en')
+                             ->willReturn(true);
+
+        $terms = new Terms();
+
+        $this->termsMapper->expects($this->once())
+                          ->method('getTermsForCountryCodeAndLanguageCode')
+                          ->with('us', 'en')
+                          ->willReturn($terms);
+
+        $this->termsMapper->expects($this->once())
+                          ->method('delete')
+                          ->with($terms);
+
+        $this->signatoryMapper->expects($this->once())
+                              ->method('deleteTerm')
+                              ->with($terms);
+
+        $result = $this->command->run($this->inputInterface, $this->outputInterface);
+        $this->assertSame($result, Command::SUCCESS);
+    }
+
+    public function testFallsBackToGlobalCountry() {
+        $this->inputInterface->method('getOption')->willReturnMap(
+            [
+                ['country', Null],
+                ['language', 'en'],
+            ]
+        );
+
+        $this->countryMapper->expects($this->once())
+                            ->method('isValidCountry')
+                            ->with(CountryMapper::GLOBAL)
+                            ->willReturn(true);
+
+        $this->languageMapper->expects($this->once())
+                             ->method('isValidLanguage')
+                             ->with('en')
+                             ->willReturn(true);
+
+        $terms = new Terms();
+
+        $this->termsMapper->expects($this->once())
+                          ->method('getTermsForCountryCodeAndLanguageCode')
+                          ->with(CountryMapper::GLOBAL, 'en')
+                          ->willReturn($terms);
+
+        $this->termsMapper->expects($this->once())
+                          ->method('delete')
+                          ->with($terms);
+
+        $this->signatoryMapper->expects($this->once())
+                              ->method('deleteTerm')
+                              ->with($terms);
+
+        $result = $this->command->run($this->inputInterface, $this->outputInterface);
+        $this->assertSame($result, Command::SUCCESS);
+    }
+
+    public function testRejectsInvalidCountry() {
+        $this->inputInterface->method('getOption')->willReturnMap(
+            [
+                ['country', 'invalid'],
+                ['language', 'en'],
+            ]
+        );
+
+        $this->countryMapper->expects($this->once())
+                            ->method('isValidCountry')
+                            ->with('invalid')
+                            ->willReturn(false);
+
+        $this->languageMapper->expects($this->never())
+                             ->method('isValidLanguage')
+                             ->with('en')
+                             ->willReturn(true);
+
+        $this->termsMapper->expects($this->never())
+                          ->method('getTermsForCountryCodeAndLanguageCode')
+                          ->with('invalid', 'en');
+
+        $this->termsMapper->expects($this->never())
+                          ->method('delete');
+
+        $this->signatoryMapper->expects($this->never())
+                              ->method('deleteTerm');
+
+        $result = $this->command->run($this->inputInterface, $this->outputInterface);
+        $this->assertSame($result, Command::FAILURE);
+    }
+
+    public function testRejectsInvalidLanguage() {
+        $this->inputInterface->method('getOption')->willReturnMap(
+            [
+                ['country', 'us'],
+                ['language', 'invalid'],
+            ]
+        );
+
+        $this->countryMapper->expects($this->once())
+                            ->method('isValidCountry')
+                            ->with('us')
+                            ->willReturn(true);
+
+        $this->languageMapper->expects($this->once())
+                             ->method('isValidLanguage')
+                             ->with('invalid')
+                             ->willReturn(false);
+
+        $this->termsMapper->expects($this->never())
+                          ->method('getTermsForCountryCodeAndLanguageCode')
+                          ->with('us', 'invalid');
+
+        $this->termsMapper->expects($this->never())
+                          ->method('delete');
+
+        $this->signatoryMapper->expects($this->never())
+                              ->method('deleteTerm');
+
+        $result = $this->command->run($this->inputInterface, $this->outputInterface);
+        $this->assertSame($result, Command::FAILURE);
+    }
+
+    public function testFailsForNonExistingTerms() {
+        $this->inputInterface->method('getOption')->willReturnMap(
+            [
+                ['country', 'us'],
+                ['language', 'en'],
+            ]
+        );
+
+        $this->countryMapper->expects($this->once())
+                            ->method('isValidCountry')
+                            ->with('us')
+                            ->willReturn(true);
+
+        $this->languageMapper->expects($this->once())
+                             ->method('isValidLanguage')
+                             ->with('en')
+                             ->willReturn(true);
+
+        $this->termsMapper->expects($this->once())
+                          ->method('getTermsForCountryCodeAndLanguageCode')
+                          ->with('us', 'en')
+                          ->willThrowException(new TermsNotFoundException);
+
+        $this->termsMapper->expects($this->never())
+                          ->method('delete');
+
+        $this->signatoryMapper->expects($this->never())
+                              ->method('deleteTerm');
+
+        $result = $this->command->run($this->inputInterface, $this->outputInterface);
+        $this->assertSame($result, Command::FAILURE);
+    }
+}

--- a/tests/SetTermsCommandTest.php
+++ b/tests/SetTermsCommandTest.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023, Marius David Wieschollek (github.public@mdns.eu)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\TermsOfService\Tests;
+
+use OCA\TermsOfService\Db\Entities\Terms;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\Input;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use OCA\TermsOfService\Command\SetTermsCommand;
+use OCA\TermsOfService\Db\Mapper\CountryMapper;
+use OCA\TermsOfService\Db\Mapper\LanguageMapper;
+use OCA\TermsOfService\Db\Mapper\TermsMapper;
+use OCA\TermsOfService\Exceptions\TermsNotFoundException;
+
+/**
+ * @group Command
+ */
+class SetTermsCommandTest extends TestCase {
+
+    /** @var CountryMapper|MockObject */
+    protected $countryMapper;
+
+    /** @var TermsMapper|MockObject */
+    protected $termsMapper;
+
+    /** @var LanguageMapper|MockObject */
+    protected $languageMapper;
+
+    /** @var Input|MockObject */
+    protected $inputInterface;
+
+    /** @var ConsoleOutput|MockObject */
+    protected $outputInterface;
+
+    /** @var SetTermsCommand */
+    protected $command;
+
+    protected function setUp(): void {
+        $this->countryMapper = $this->createMock(CountryMapper::class);
+        $this->termsMapper = $this->createMock(TermsMapper::class);
+        $this->languageMapper = $this->createMock(LanguageMapper::class);
+        $this->inputInterface = $this->createMock(Input::class);
+        $this->outputInterface = $this->createMock(ConsoleOutput::class);
+
+        $this->command = new SetTermsCommand(
+            $this->termsMapper,
+            $this->countryMapper,
+            $this->languageMapper,
+        );
+    }
+
+    public function testUpdatesExistingTerms() {
+        $this->inputInterface->method('getOption')->willReturnMap(
+            [
+                ['country', 'us'],
+                ['language', 'en'],
+            ]
+        );
+        $this->inputInterface->method('getArgument')->willReturn('text', 'some random text');
+
+        $this->countryMapper->expects($this->once())
+                            ->method('isValidCountry')
+                            ->with('us')
+                            ->willReturn(true);
+
+        $this->languageMapper->expects($this->once())
+                             ->method('isValidLanguage')
+                             ->with('en')
+                             ->willReturn(true);
+
+        $terms = new Terms();
+        $terms->setId(1);
+
+        $this->termsMapper->expects($this->once())
+                          ->method('getTermsForCountryCodeAndLanguageCode')
+                          ->with('us', 'en')
+                          ->willReturn($terms);
+
+        $this->termsMapper->expects($this->once())
+                          ->method('update')
+                          ->with($terms);
+
+        $result = $this->command->run($this->inputInterface, $this->outputInterface);
+        $this->assertSame($result, Command::SUCCESS);
+    }
+
+    public function testCreatesNewTerms() {
+        $this->inputInterface->method('getOption')->willReturnMap(
+            [
+                ['country', 'us'],
+                ['language', 'en'],
+            ]
+        );
+        $this->inputInterface->method('getArgument')->willReturn('text', 'some random text');
+
+        $this->countryMapper->expects($this->once())
+                            ->method('isValidCountry')
+                            ->with('us')
+                            ->willReturn(true);
+
+        $this->languageMapper->expects($this->once())
+                             ->method('isValidLanguage')
+                             ->with('en')
+                             ->willReturn(true);
+
+        $terms = new Terms();
+        $terms->setId(null);
+
+        $this->termsMapper->expects($this->once())
+                          ->method('getTermsForCountryCodeAndLanguageCode')
+                          ->with('us', 'en')
+                          ->willThrowException(new TermsNotFoundException);
+
+        $this->termsMapper->expects($this->once())
+                          ->method('insert');
+
+        $result = $this->command->run($this->inputInterface, $this->outputInterface);
+        $this->assertSame($result, Command::SUCCESS);
+    }
+
+    public function testFallsBackToGlobalCountry() {
+        $this->inputInterface->method('getOption')->willReturnMap(
+            [
+                ['country', Null],
+                ['language', 'en'],
+            ]
+        );
+        $this->inputInterface->method('getArgument')->with('text')->willReturn('some random text');
+
+        $this->countryMapper->expects($this->once())
+                            ->method('isValidCountry')
+                            ->with(CountryMapper::GLOBAL)
+                            ->willReturn(true);
+
+        $this->languageMapper->expects($this->once())
+                             ->method('isValidLanguage')
+                             ->with('en')
+                             ->willReturn(true);
+
+        $terms = new Terms();
+        $terms->setId(1);
+
+        $this->termsMapper->expects($this->once())
+                          ->method('getTermsForCountryCodeAndLanguageCode')
+                          ->with(CountryMapper::GLOBAL, 'en')
+                          ->willReturn($terms);
+
+        $this->termsMapper->expects($this->once())
+                          ->method('update')
+                          ->with($terms);
+
+        $result = $this->command->run($this->inputInterface, $this->outputInterface);
+        $this->assertSame($result, Command::SUCCESS);
+    }
+
+    public function testRejectsInvalidCountry() {
+        $this->inputInterface->method('getOption')->willReturnMap(
+            [
+                ['country', 'invalid'],
+                ['language', 'en'],
+            ]
+        );
+        $this->inputInterface->method('getArgument')->with('text')->willReturn('some random text');
+
+        $this->countryMapper->expects($this->once())
+                            ->method('isValidCountry')
+                            ->with('invalid')
+                            ->willReturn(false);
+
+        $this->languageMapper->expects($this->never())
+                             ->method('isValidLanguage')
+                             ->with('en')
+                             ->willReturn(true);
+
+        $this->termsMapper->expects($this->never())
+                          ->method('getTermsForCountryCodeAndLanguageCode')
+                          ->with('invalid', 'en');
+
+        $result = $this->command->run($this->inputInterface, $this->outputInterface);
+        $this->assertSame($result, Command::FAILURE);
+    }
+
+    public function testRejectsInvalidLanguage() {
+        $this->inputInterface->method('getOption')->willReturnMap(
+            [
+                ['country', 'us'],
+                ['language', 'invalid'],
+            ]
+        );
+        $this->inputInterface->method('getArgument')->with('text')->willReturn('some random text');
+
+        $this->countryMapper->expects($this->once())
+                            ->method('isValidCountry')
+                            ->with('us')
+                            ->willReturn(true);
+
+        $this->languageMapper->expects($this->once())
+                             ->method('isValidLanguage')
+                             ->with('invalid')
+                             ->willReturn(false);
+
+        $this->termsMapper->expects($this->never())
+                          ->method('getTermsForCountryCodeAndLanguageCode')
+                          ->with('us', 'invalid');
+
+        $result = $this->command->run($this->inputInterface, $this->outputInterface);
+        $this->assertSame($result, Command::FAILURE);
+    }
+
+    public function testRejectsInvalidBody() {
+        $this->inputInterface->method('getOption')->willReturnMap(
+            [
+                ['country', 'us'],
+                ['language', 'en'],
+            ]
+        );
+        $this->inputInterface->method('getArgument')->with('text')->willReturn('');
+
+        $this->countryMapper->expects($this->once())
+                            ->method('isValidCountry')
+                            ->with('us')
+                            ->willReturn(true);
+
+        $this->languageMapper->expects($this->once())
+                             ->method('isValidLanguage')
+                             ->with('en')
+                             ->willReturn(true);
+
+        $this->termsMapper->expects($this->never())
+                          ->method('getTermsForCountryCodeAndLanguageCode')
+                          ->with('us', 'en');
+
+        $result = $this->command->run($this->inputInterface, $this->outputInterface);
+        $this->assertSame($result, Command::FAILURE);
+    }
+}


### PR DESCRIPTION
This PR adds two occ commands: 

-  `terms_of_service:term:set` to create or update the tos for the given country and language
-  `terms_of_service:term:delete` to delete the tos for the given country and language

This makes it easier to use the app in automated environments, e.g. to add TOS for demo instances or to automatically deploy TOS from a centralized source.