### PR TITLE
[stable4.7] chore: Require at least Nextcloud 32

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,7 +33,7 @@ This product includes GeoLite2 data created by MaxMind, available from [maxmind.
 	<screenshot>https://github.com/nextcloud/terms_of_service/raw/master/docs/notification-and-settings.png</screenshot>
 
 	<dependencies>
-		<nextcloud min-version="30" max-version="34" />
+		<nextcloud min-version="32" max-version="34" />
 	</dependencies>
 
 	<commands>


### PR DESCRIPTION
Backport of https://github.com/nextcloud/terms_of_service/pull/1192